### PR TITLE
add BitSet::iter_from(&self, start: usize) function

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,13 +13,25 @@ pub struct Iter<'a, T> {
   bit: usize,
 }
 
-impl<'a, T> Iter<'a, T> {
+impl<'a, T> Iter<'a, T> 
+where
+  T: BitBlock
+{
   pub(crate) fn new(set: &'a BitSet<T>) -> Self {
     Self {
       slice: &set.vec,
       num_bits: set.num_bits,
       index: 0,
       bit: 0,
+    }
+  }
+  pub(crate) fn new_from(set: &'a BitSet<T>, start: usize) -> Self {
+    let (index, bit) = (start / T::NUM_BITS, start % T::NUM_BITS);
+    Self {
+      slice: &set.vec,
+      num_bits: set.num_bits,
+      index,
+      bit,
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,23 @@ where
     Iter::new(self)
   }
 
+  /// Iterates over the `BitSet`, producing `usize`s representing the elements
+  /// in the set, in ascending order, from a given start bit index
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use bittyset::bitset;
+  ///
+  /// let set1 = bitset![7,15,3,5,18];
+  /// let vec1 = set1.iter_from(15).collect::<Vec<usize>>();
+  ///
+  /// assert_eq!(vec1, vec![15,18]);
+  /// ```
+  pub fn iter_from(&self, start: usize) -> Iter<T> {
+    Iter::new_from(self, start)
+  }
+
   /// Returns the number of elements in the set.
   pub fn len(&self) -> usize {
     self.vec.iter().map(|x| x.count_ones() as usize).sum()


### PR DESCRIPTION
Hi,

  could you please merge my changes and make it public on crates (don't know the process yet).

Having this function (iteration from a specified start index) would help me a lot.

Thank you,
  Karol 